### PR TITLE
feat: explicit any type

### DIFF
--- a/lib/jet_credo/checks/explicit_any_type.ex
+++ b/lib/jet_credo/checks/explicit_any_type.ex
@@ -1,0 +1,75 @@
+defmodule JetCredo.Checks.ExplicitAnyType do
+  @moduledoc false
+
+  use Credo.Check,
+    base_priority: :high,
+    category: :refactor,
+    explanations: [
+      check: """
+      Disallow the `any` type.
+
+      Using the any type can make debugging very difficult,
+      especially when the call chain is long.
+
+      It is preferable to define and use a well-defined type instead of any in types.
+
+      Example:
+
+          # preferred
+          @type reason() :: :bad_request | :not_found
+          @spec request() :: :ok | {:error, :bad_request}
+
+          # NOT preferred
+          @type reason() :: term()
+          @spec request() :: :ok | {:error, term()}
+
+      See also:
+      - https://github.com/Byzanteam/jet_credo/issues/1
+      - https://github.com/Byzanteam/jet-tower/issues/86
+      """
+    ]
+
+  @doc false
+  @impl Credo.Check
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  @type_catalogs [:type, :typep, :spec, :callback, :macrocallback]
+
+  for type_catalog <- @type_catalogs do
+    defp traverse(
+           {:@, _meta, [{unquote(type_catalog), _type_meta, args}]} = ast,
+           issues,
+           issue_meta
+         ) do
+      {ast, find_any_type(unquote(type_catalog), args, issues, issue_meta)}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp find_any_type(type_catalog, ast, issues, issue_meta) do
+    Credo.Code.prewalk(
+      ast,
+      fn
+        {key, meta, []} = ast, acc when key in [:any, :term] ->
+          options = [
+            message: "Explicit `#{to_string(key)}()` type found in @#{to_string(type_catalog)}",
+            trigger: "#{to_string(key)}()",
+            line_no: meta[:line],
+            column_no: meta[:column]
+          ]
+
+          {ast, [format_issue(issue_meta, options) | acc]}
+
+        ast, acc ->
+          {ast, acc}
+      end,
+      issues
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,10 @@ defmodule JetCredo.MixProject do
       version: "0.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      dialyzer: [
+        plt_add_apps: [:credo]
+      ]
     ]
   end
 

--- a/test/jet_credo/checks/explicit_any_type_test.exs
+++ b/test/jet_credo/checks/explicit_any_type_test.exs
@@ -1,0 +1,182 @@
+defmodule JetCredo.Checks.NoExplicitAnyTypeTest do
+  use Credo.Test.Case
+
+  alias JetCredo.Checks.ExplicitAnyType
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> refute_issues()
+
+    """
+    defmodule CredoSampleModule do
+      @typep private_type() :: String.t()
+      @type public_type() :: String.t() | private_type()
+
+      @type arg_type(t) :: t | nil
+
+      @spec foo() :: :bar
+      def foo(), do: :bar
+
+      @callback callback_fn() :: :ok
+      @macrocallback macrocallback_fn() :: :ok
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> refute_issues()
+  end
+
+  test "it should NOT report expected code that calls any or term functions" do
+    """
+    defmodule CredoSampleModule do
+      any()
+
+      def any do
+        term()
+      end
+
+      term()
+
+      def term do
+        any()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> refute_issues()
+  end
+
+  test "it should report code that uses any in @type" do
+    """
+    defmodule CredoSampleModule do
+      @type any_type() :: any()
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+
+    """
+    defmodule CredoSampleModule do
+      @type term_type() :: term()
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+  end
+
+  test "it should report code that uses any in @typep" do
+    """
+    defmodule CredoSampleModule do
+      @type public_type() :: any_type() 
+      @typep any_type() :: any()
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+
+    """
+    defmodule CredoSampleModule do
+      @type public_type() :: term_type()
+      @typep term_type() :: term()
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+  end
+
+  test "it should report code that uses any in @spec" do
+    """
+    defmodule CredoSampleModule do
+      @spec any_fun() :: any()
+      def any_fun(), do: :ok
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+
+    """
+    defmodule CredoSampleModule do
+      @spec term_fun() :: term()
+      def term_fun(), do: :ok
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+  end
+
+  test "it should report code that uses any in @callback" do
+    """
+    defmodule CredoSampleModule do
+      @callback any_callback() :: any()
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+
+    """
+    defmodule CredoSampleModule do
+      @callback term_callback() :: any()
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+  end
+
+  test "it should report code that uses any in @macrocallback" do
+    """
+    defmodule CredoSampleModule do
+      @macrocallback any_callback() :: any()
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+
+    """
+    defmodule CredoSampleModule do
+      @macrocallback term_callback() :: any()
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issue()
+  end
+
+  test "it should report code" do
+    """
+    defmodule CredoSampleModule do
+      @type any_type() :: any() | private_any_type()
+      @type term_type() :: term() | private_term_type()
+
+      @spec term_fun() :: term()
+      def term_fun(), do: :ok
+
+      @spec any_fun() :: any()
+      def any_fun(), do: :ok
+
+      @typep private_any_type() :: any()
+      @typep private_term_type() :: term()
+
+      @macrocallback any_callback() :: any()
+      @macrocallback term_callback() :: any()
+    end
+    """
+    |> to_source_file()
+    |> run_check(ExplicitAnyType)
+    |> assert_issues(fn issues -> assert Enum.count(issues) == 8 end)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+{:ok, _} = Application.ensure_all_started(:credo)
+
 ExUnit.start()


### PR DESCRIPTION
close https://github.com/Byzanteam/jet_credo/issues/1

```
Disallow the `any` type.

Using the any type can make debugging very difficult,
especially when the call chain is long.

It is preferable to define and use a well-defined type instead of any in types.

Example:

    # preferred
    @type reason() :: :bad_request | :not_found
    @spec request() :: :ok | {:error, :bad_request}

    # NOT preferred
    @type reason() :: term()
    @spec request() :: :ok | {:error, term()}
```